### PR TITLE
two other ways to change skins

### DIFF
--- a/method1_from_ui.R
+++ b/method1_from_ui.R
@@ -1,0 +1,60 @@
+
+
+# Method 1 : choose skin in UI --------------------------------------------
+
+# In this method, we define a skin in the UI
+# This apply to all sliders in the app
+
+# Todo : instead of recreating a complete dependency, use shiny's dep since all skins are available
+# https://github.com/rstudio/shiny/tree/master/inst/www/shared/ionrangeslider/css
+
+
+
+
+# Fun ---------------------------------------------------------------------
+
+
+chooseSliderSkin <- function(skin = c("Shiny", "Flat", "Modern", "Nice",
+                                      "Simple", "HTML5", "Round", "Square")) {
+  skin <- match.arg(arg = skin)
+  tagList(
+    htmltools::suppressDependencies("ionrangeslider"),
+    htmltools::attachDependencies(
+      x = tags$div(),
+      value = htmltools::htmlDependency(
+        "ionrangesliderSkin", "2.1.6", c(href="shared/ionrangeslider"),
+        script = "js/ion.rangeSlider.min.js",
+        # ion.rangeSlider also needs normalize.css, which is already included in
+        # Bootstrap.
+        stylesheet = c(
+          "css/ion.rangeSlider.css",
+          paste0("css/ion.rangeSlider.skin", skin, ".css")
+        )
+      ), append = FALSE
+    )
+  )
+}
+
+
+
+
+# Demo --------------------------------------------------------------------
+
+
+ui <- fluidPage(
+  chooseSliderSkin("Flat"),
+  sliderInput("obs", "Number of observations:",
+              min = 0, max = 1000, value = 500
+  ),
+  plotOutput("distPlot")
+)
+
+server <- function(input, output) {
+  
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+  
+}
+
+shinyApp(ui, server)

--- a/method2_from_server.R
+++ b/method2_from_server.R
@@ -1,0 +1,88 @@
+
+
+
+# Method 2 : from server --------------------------------------------------
+
+# In this method, we can choose skin from server
+# This apply to all sliders in the app
+
+# But you to use a function in UI to initialize the skin and modify the dependencies to be able to modify them
+
+# Todo : instead of recreating a complete dependency, use shiny's dep since all skins are available
+# https://github.com/rstudio/shiny/tree/master/inst/www/shared/ionrangeslider/css
+
+
+
+
+# Fun ---------------------------------------------------------------------
+
+
+updateSliderSkinUi <- function(skin = c("Shiny", "Flat", "Modern", "Nice",
+                                      "Simple", "HTML5", "Round", "Square")) {
+  skin <- match.arg(arg = skin)
+  singleton(
+    tags$head(
+      suppressDependencies("ionrangeslider"),
+      tags$script(src = "shared/ionrangeslider/js/ion.rangeSlider.min.js"),
+      tags$link(href = "shared/ionrangeslider/css/ion.rangeSlider.css", rel="stylesheet"),
+      tags$link(href = paste0("shared/ionrangeslider/css/ion.rangeSlider.skin", skin, ".css"), rel="stylesheet", id = "skinCss"),
+      tags$script(
+        "Shiny.addCustomMessageHandler('update-skin', function(message) {
+        var css = 'shared/ionrangeslider/css/ion.rangeSlider.skin' + message.skin + '.css';
+        $('#skinCss').attr('href', css);
+        });"
+      )
+    )
+  )
+}
+
+updateSliderSkin <- function(session, skin = c("Shiny", "Flat", "Modern", "Nice",
+                                      "Simple", "HTML5", "Round", "Square")) {
+  skin <- match.arg(arg = skin)
+  session$sendCustomMessage(
+    type = "update-skin",
+    message = list(skin = skin)
+  )
+}
+
+
+
+
+# Demo --------------------------------------------------------------------
+
+
+ui <- fluidPage(
+  updateSliderSkinUi("Flat"),
+  sliderInput("obs", "Number of observations:",
+              min = 0, max = 1000, value = 500
+  ),
+  plotOutput("distPlot"),
+  selectInput(
+    inputId = "slider_skin", 
+    label = "Choose a skin",
+    choices = c(
+      "Shiny",
+      "Flat", 
+      "Modern", 
+      "Nice",
+      "Simple",
+      "HTML5",
+      "Round",
+      "Square"
+    ), selected = "Flat"
+  )
+)
+
+server <- function(input, output, session) {
+  
+  output$distPlot <- renderPlot({
+    hist(rnorm(input$obs))
+  })
+  
+  observeEvent(input$slider_skin, {
+    updateSliderSkin(session, skin = input$slider_skin)
+  })
+  
+}
+
+shinyApp(ui, server)


### PR DESCRIPTION
I added two other ways to change skins without re-writing `shiny::sliderInput`, what do you think ?
I think method 1 is a good option.

For using several skins, I don't see an other method than rewriting the CSS and use `data-extra-classes`, but this require more developpement and it's not guaranteed to work...